### PR TITLE
feat(graph): Scheduler 상태를 Graph로 변환하고 PyG 구조로 내보내는 GNN 입력 파이프라인 구현

### DIFF
--- a/src/rl_scheduler/graph/__init__.py
+++ b/src/rl_scheduler/graph/__init__.py
@@ -1,0 +1,9 @@
+from .sync import SchedulerGraphSync
+from .pyg_converter import graph_to_pyg
+from .builder import build_graph_from_scheduler
+
+__all__ = [
+    "SchedulerGraphSync",
+    "graph_to_pyg",
+    "build_graph_from_scheduler"
+]

--- a/src/rl_scheduler/graph/builder.py
+++ b/src/rl_scheduler/graph/builder.py
@@ -1,0 +1,101 @@
+# ── builder.py ────────────────────────────────────────────
+import networkx as nx
+
+# ---------- 1. NetworkX 그래프 생성 ----------
+def build_graph_from_scheduler(sch) -> nx.MultiDiGraph:
+    """
+    Convert a Scheduler instance into a directed multigraph.
+
+    Node ids:
+        op_{instance_id}
+        mach_{machine_id}
+    """
+    G = nx.MultiDiGraph()
+
+    # 1-A. Machine nodes
+    for m in sch.machine_instances:
+        mt_id = m.machine_template.machine_template_id
+        G.add_node(
+            f"mach_{mt_id}", ntype="machine",
+            features={
+                "id": mt_id,
+                "supported_types": m.machine_template.supported_operation_type_codes,
+                "queue_len": len(getattr(m, "assigned_operations", [])),
+                "busy_until": getattr(m, "last_assigned_end_time", 0.0),
+            },
+        )
+
+    # 1-B. Operation nodes
+    for job_type in sch.job_instances:
+        for job_inst in job_type:
+            for op in job_inst.operation_instance_sequence:
+                ot_id = op.operation_template.operation_template_id
+                G.add_node(
+                    f"op_{ot_id}", ntype="operation",
+                    features={
+                        "id": ot_id,
+                        "type": op.type_code,
+                        "duration": op.duration,
+                        "job_id": job_inst.job_template.job_template_id,
+                    },
+                )
+
+                # logical edge for precedence
+                if op.successor:
+                    succ_ot_id = op.successor.operation_template.operation_template_id
+                    G.add_edge(
+                        f"op_{ot_id}", f"op_{succ_ot_id}",
+                        key=f"log_{ot_id}_{succ_ot_id}", etype="logical",
+                        features={"label": "L"},
+                    )
+                    G.add_edge(
+                        f"op_{succ_ot_id}", f"op_{ot_id}",
+                        key=f"log_{succ_ot_id}_{ot_id}", etype="logical",
+                        features={"label": "L"},
+                    )
+
+    # 1-C. Eligibility edges (type_valid)
+    for m in sch.machine_instances:
+        m_id = m.machine_template.machine_template_id
+        for n, d in G.nodes(data=True):
+            if d.get("ntype") != "operation":
+                continue
+            if d["features"]["type"] in m.machine_template.supported_operation_type_codes:
+                G.add_edge(
+                    f"mach_{m_id}", n,
+                    key=f"type_valid_{m_id}_{n}", etype="type_valid",
+                    features={"label": "T"},
+                )
+
+    # 1-D. Dynamic assignment and completion edges
+    for job_type in sch.job_instances:
+        for job_inst in job_type:
+            for op in job_inst.operation_instance_sequence:
+                # assignment edge
+                if op.processing_machine:
+                    mt_id = op.processing_machine.machine_template.machine_template_id
+                    ot_id = op.operation_template.operation_template_id
+                    G.add_edge(
+                        f"mach_{mt_id}", f"op_{ot_id}",
+                        key=f"assign_{ot_id}", etype="assignment",
+                        features={
+                            "start_time": op.start_time,
+                            "end_time": op.end_time,
+                            "job_instance_id": job_inst.job_instance_id,
+                            "label": f"A({job_inst.job_instance_id})",
+                        },
+                    )
+                # completion edge
+                if op.end_time is not None and op.successor:
+                    ot_id = op.operation_template.operation_template_id
+                    succ_ot_id = op.successor.operation_template.operation_template_id
+                    G.add_edge(
+                        f"op_{ot_id}", f"op_{succ_ot_id}",
+                        key=f"compl_{ot_id}", etype="completion",
+                        features={
+                            "completion_time": op.end_time,
+                            "job_instance_id": job_inst.job_instance_id,
+                            "label": f"C({job_inst.job_instance_id})",
+                        },
+                    )
+    return G

--- a/src/rl_scheduler/graph/pyg_converter.py
+++ b/src/rl_scheduler/graph/pyg_converter.py
@@ -1,0 +1,58 @@
+# ── pyg_converter.py ────────────────────────────────────────────
+from typing import Dict, List
+import networkx as nx
+import torch
+from torch_geometric.data import Data
+
+# ---------- 2. PyG Data 변환 ----------
+def encode_node_feat(feat: Dict) -> List[float]:
+    """예시: 간단한 실수 벡터 인코딩 (원-핫/임베딩은 따로)."""
+    # build raw feature list
+    raw = [
+        feat.get("id", 0),
+        feat.get("duration", 0),
+        feat.get("type", 0),
+        feat.get("job_id", 0),
+        feat.get("queue_len", 0),
+        feat.get("busy_until", 0),
+    ]
+    # convert all to float, fallback to 0.0 on error
+    out = []
+    for v in raw:
+        try:
+            out.append(float(v))
+        except Exception:
+            out.append(0.0)
+    return out
+
+def encode_edge_feat(feat: Dict) -> List[float]:
+    # 시간 정보가 없으면 0.0
+    return [
+        feat.get("start_time", 0.0),
+        feat.get("end_time", 0.0),
+        feat.get("completion_time", 0.0),
+    ]
+
+ETYPE2IDX = {"type_valid": 0, "assignment": 1, "logical": 2, "completion": 3}
+NTYPE2IDX = {"operation": 0, "machine": 1}
+
+def graph_to_pyg(G: nx.MultiDiGraph) -> Data:
+    node_map = {n: i for i, n in enumerate(G.nodes)}
+    x, ntypes = [], []
+    for n in G.nodes:
+        x.append(encode_node_feat(G.nodes[n]["features"]))
+        ntypes.append(NTYPE2IDX[G.nodes[n]["ntype"]])
+
+    edge_idx, edge_attr, etypes = [], [], []
+    for u, v, k, d in G.edges(keys=True, data=True):
+        edge_idx.append([node_map[u], node_map[v]])
+        edge_attr.append(encode_edge_feat(d.get("features", {})))
+        etypes.append(ETYPE2IDX[d["etype"]])
+
+    return Data(
+        x=torch.tensor(x, dtype=torch.float),
+        edge_index=torch.tensor(edge_idx).t().contiguous(),
+        edge_attr=torch.tensor(edge_attr, dtype=torch.float),
+        edge_type=torch.tensor(etypes, dtype=torch.long),
+        node_type=torch.tensor(ntypes, dtype=torch.long),
+    )

--- a/src/rl_scheduler/graph/pyg_converter.py
+++ b/src/rl_scheduler/graph/pyg_converter.py
@@ -1,37 +1,44 @@
-# ── pyg_converter.py ────────────────────────────────────────────
 from typing import Dict, List
 import networkx as nx
 import torch
 from torch_geometric.data import Data
 
 # ---------- 2. PyG Data 변환 ----------
-def encode_node_feat(feat: Dict) -> List[float]:
-    """예시: 간단한 실수 벡터 인코딩 (원-핫/임베딩은 따로)."""
-    # build raw feature list
-    raw = [
-        feat.get("id", 0),
-        feat.get("duration", 0),
-        feat.get("type", 0),
-        feat.get("job_id", 0),
-        feat.get("queue_len", 0),
-        feat.get("busy_until", 0),
-    ]
-    # convert all to float, fallback to 0.0 on error
-    out = []
-    for v in raw:
-        try:
-            out.append(float(v))
-        except Exception:
-            out.append(0.0)
-    return out
 
-def encode_edge_feat(feat: Dict) -> List[float]:
-    # 시간 정보가 없으면 0.0
-    return [
-        feat.get("start_time", 0.0),
-        feat.get("end_time", 0.0),
-        feat.get("completion_time", 0.0),
-    ]
+# 노드 타입별 필드 정의
+def encode_node_feat(feat: Dict, ntype: str) -> List[float]:
+    """노드 타입별 feature 인코딩."""
+    if ntype == "operation":
+        fields = [
+            feat.get("id", 0),          # operation id
+            feat.get("type", 0),
+            feat.get("duration", 0),
+            feat.get("job_id", 0),
+        ]
+    elif ntype == "machine":
+        fields = [
+            feat.get("id", 0),          # machine id
+            feat.get("queue_len", 0),
+            feat.get("busy_until", 0),  # 추가: busy_until
+            0,                          # padding (operation 노드와 길이 맞추기 위함)
+        ]
+    else:
+        fields = []
+    return [float(v) for v in fields]
+
+# 엣지 타입별 feature 정의
+def encode_edge_feat(feat: Dict, etype: str) -> List[float]:
+    """엣지 타입에 따른 feature 인코딩."""
+    if etype == "assignment":
+        return [
+            float(feat.get("start_time", 0.0)),
+            float(feat.get("end_time", 0.0)),
+            float(feat.get("repetition", 0.0)),
+        ]
+    elif etype == "completion":
+        return [float(feat.get("repetition", 0.0))]
+    else:  # type_valid, logical 등은 feature 없음
+        return []
 
 ETYPE2IDX = {"type_valid": 0, "assignment": 1, "logical": 2, "completion": 3}
 NTYPE2IDX = {"operation": 0, "machine": 1}
@@ -39,15 +46,24 @@ NTYPE2IDX = {"operation": 0, "machine": 1}
 def graph_to_pyg(G: nx.MultiDiGraph) -> Data:
     node_map = {n: i for i, n in enumerate(G.nodes)}
     x, ntypes = [], []
-    for n in G.nodes:
-        x.append(encode_node_feat(G.nodes[n]["features"]))
-        ntypes.append(NTYPE2IDX[G.nodes[n]["ntype"]])
+
+    for n, d in G.nodes(data=True):
+        ntype = d["ntype"]
+        x.append(encode_node_feat(d["features"], ntype))
+        ntypes.append(NTYPE2IDX[ntype])
 
     edge_idx, edge_attr, etypes = [], [], []
     for u, v, k, d in G.edges(keys=True, data=True):
+        etype = d["etype"]
         edge_idx.append([node_map[u], node_map[v]])
-        edge_attr.append(encode_edge_feat(d.get("features", {})))
-        etypes.append(ETYPE2IDX[d["etype"]])
+        edge_attr.append(encode_edge_feat(d.get("features", {}), etype))
+        etypes.append(ETYPE2IDX[etype])
+
+    # padding edge_attr to uniform length
+    max_len = max(len(e) for e in edge_attr)
+    for e in edge_attr:
+        while len(e) < max_len:
+            e.append(0.0)
 
     return Data(
         x=torch.tensor(x, dtype=torch.float),

--- a/src/rl_scheduler/graph/sync.py
+++ b/src/rl_scheduler/graph/sync.py
@@ -1,0 +1,57 @@
+# ── sync.py ──────────────────────────────────────────────
+import networkx as nx
+from typing import Optional
+from .builder import build_graph_from_scheduler  # import graph builder
+from datetime import datetime
+
+class SchedulerGraphSync:
+    """Keeps a live NetworkX MultiDiGraph in sync with Scheduler state."""
+    def __init__(self, scheduler):
+        self.sch = scheduler
+        self.G   = build_graph_from_scheduler(scheduler)  # 첫 스냅숏
+
+    # ---------- 호출 지점 ①: Scheduler.step 직후 ----------
+    def on_assignment(self, machine, op):
+        """Update graph when an operation is just scheduled."""
+        m_node = f"mach_{machine.machine_template.machine_template_id}"
+        o_node = f"op_{op.operation_template.operation_template_id}"
+
+        # (1) 머신 노드 실시간 상태 갱신
+        m_feat = self.G.nodes[m_node]["features"]
+        m_feat["queue_len"]   = len(machine.assigned_operations)
+        m_feat["busy_until"]  = machine.last_assigned_end_time
+
+        # (2) Eligibility edge(기본) 제거 → Assignment edge 추가
+        elig_key = f"elig_{machine.machine_template.machine_template_id}_{o_node}"
+        if self.G.has_edge(m_node, o_node, key=elig_key):
+            self.G.remove_edge(m_node, o_node, key=elig_key)
+
+        self.G.add_edge(
+            m_node, o_node,
+            key=f"assign_{op.operation_template.operation_template_id}",
+            etype="assignment",
+            features={
+                "start_time": op.start_time,
+                "end_time":   op.end_time,
+                "job_instance_id": op.job_instance.job_instance_id
+            }
+        )
+
+    # ---------- 호출 지점 ②: OperationInstance.schedule 내부 ----------
+    def on_completion(self, op):
+        """Update graph when an operation finishes (end_time set)."""
+        if op.successor is None or op.end_time is None:
+            return  # nothing to do
+
+        u_node = f"op_{op.operation_template.operation_template_id}"
+        v_node = f"op_{op.successor.operation_template.operation_template_id}"
+
+        self.G.add_edge(
+            u_node, v_node,
+            key=f"compl_{op.operation_template.operation_template_id}_{datetime.utcnow().timestamp()}",
+            etype="completion",
+            features={
+                "completion_time": op.end_time,
+                "job_instance_id": op.job_instance.job_instance_id
+            }
+        )

--- a/src/rl_scheduler/tests/graph/test_builder_and_draw.py
+++ b/src/rl_scheduler/tests/graph/test_builder_and_draw.py
@@ -12,56 +12,54 @@ from rl_scheduler.graph.builder import build_graph_from_scheduler
 from rl_scheduler.graph.pyg_converter import graph_to_pyg
 from rl_scheduler.config_path import INSTANCES_DIR
 
-# ───────────────────────── 경로 세팅 ────────────────────────────
+# ── 테스트 인스턴스 경로 ────────────────────────────────────────
 CONTRACTS = INSTANCES_DIR / "contracts"  / "C-test0.json"
 MACHINES  = INSTANCES_DIR / "machines"   / "M-test0-2.json"
 JOBS      = INSTANCES_DIR / "jobs"       / "J-test0-2.json"
 OPS       = INSTANCES_DIR / "operations" / "O-test0.json"
 
-OUT_DIR   = Path("./graph_debug_png")
+OUT_DIR = Path("./graph_debug_png")
 OUT_DIR.mkdir(exist_ok=True)
 
-# ─────────────────────── 시각화 유틸 ────────────────────────────
-def quick_draw(G: nx.MultiDiGraph, title: str, save_path: Path | None = None):
+# ── 간단 시각화 함수 ───────────────────────────────────────────
+def quick_draw(G: nx.MultiDiGraph, title: str, path: Path | None = None) -> None:
     pos = nx.spring_layout(G, seed=0)
+
     node_colors = [
-        "skyblue" if G.nodes[n]["ntype"] == "operation" else "lightgreen"
+        "skyblue"   if G.nodes[n]["ntype"] == "operation" else "lightgreen"
         for n in G.nodes
     ]
     edge_colors = [
-        "red"       if d.get("etype") == "completion"
-        else "blue" if d.get("etype") == "assignment"
-        else "gray" if d.get("etype") == "type_valid"
+        "red"       if d["etype"] == "completion"
+        else "blue" if d["etype"] == "assignment"
+        else "gray" if d["etype"] == "type_valid"
         else "lightgray"
         for _, _, d in G.edges(data=True)
     ]
 
     fig, ax = plt.subplots(figsize=(8, 4))
     nx.draw(
-        G, pos, ax=ax, with_labels=True,
-        node_color=node_colors, edge_color=edge_colors,
-        node_size=900, font_size=8
+        G, pos, ax=ax,
+        with_labels=True, node_color=node_colors, edge_color=edge_colors,
+        node_size=900, font_size=7
     )
-
     edge_labels = {
         (u, v): d["label"]
         for u, v, d in G.edges(data=True) if "label" in d
     }
     nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels, font_size=7, ax=ax)
-    ax.set_title(title)
+
+    ax.set_title(title, fontsize=10)
     ax.axis("off")
     plt.tight_layout()
-
-    if save_path:
-        fig.savefig(save_path, dpi=150)
-    else:
-        plt.show()
-
+    if path:
+        fig.savefig(path, dpi=150)
     plt.close(fig)
 
-# ──────────────────────── 테스트 케이스 ─────────────────────────
-def test_graph_over_steps():
-    # 1) Scheduler 초기화
+# ── 메인 테스트 ───────────────────────────────────────────────
+def test_graph_over_steps(tmp_path: Path = OUT_DIR):
+    """Build → step() 2회 → 그래프/PyG 변환 및 무결성 확인."""
+    # 1) scheduler 초기화
     det = DeterministicGenerator(CONTRACTS)
     reps  = det.load_repetition()
     profs = det.load_profit_fn()
@@ -74,23 +72,68 @@ def test_graph_over_steps():
     )
     sched.reset(reps, profs)
 
-    # 2) STEP 0 ─ 초기 그래프
+    # 2) Step 0 : 초기 그래프
     G0 = build_graph_from_scheduler(sched)
-    _  = graph_to_pyg(G0)          # shape 확인만
-    quick_draw(G0, "Step 0 (initial)", OUT_DIR / "graph_step0.png")
+    _  = graph_to_pyg(G0)                # 변환만 (shape-check)
+    quick_draw(G0, "Step 0 (initial)", tmp_path / "graph_step0.png")
 
-    # 3) STEP 1  (machine 0, job 0, rep 0)
+    # 3) Step 1 : (machine 0, job 0, rep 0)
     sched.step(chosen_machine_id=0, chosen_job_id=0, chosen_repetition=0)
     G1 = build_graph_from_scheduler(sched)
     _  = graph_to_pyg(G1)
-    quick_draw(G1, "Step 1  (M0 → J0-R0)", OUT_DIR / "graph_step1.png")
+    quick_draw(G1, "Step 1  (M0 → J0-R0)", tmp_path / "graph_step1.png")
 
-    # 4) STEP 2  (machine 0, job 1, rep 0)
+    # 4) Step 2 : (machine 0, job 1, rep 0)
     sched.step(chosen_machine_id=0, chosen_job_id=1, chosen_repetition=0)
     G2 = build_graph_from_scheduler(sched)
     _  = graph_to_pyg(G2)
-    quick_draw(G2, "Step 2  (M0 → J1-R0)", OUT_DIR / "graph_step2.png")
+    quick_draw(G2, "Step 2  (M0 → J1-R0)", tmp_path / "graph_step2.png")
 
-    # 간단 무결성 체크 (노드·엣지 수 증가 확인)
+    # ── 간단 무결성 체크 ─────────────────────────────────────
     assert G1.number_of_edges() >= G0.number_of_edges()
     assert G2.number_of_edges() >= G1.number_of_edges()
+    # assignment·completion 엣지가 실제로 추가되었는지
+    assert any(d["etype"] == "assignment"  for _, _, d in G1.edges(data=True))
+    assert any(d["etype"] == "completion"  for _, _, d in G2.edges(data=True))
+
+
+# ── PyG 변환 무결성 테스트 ────────────────────────────────────
+def test_pyg_conversion_shapes():
+    """builder → graph_to_pyg 변환 시 텐서 차원 및 매핑 체크."""
+    det   = DeterministicGenerator(CONTRACTS)
+    reps  = det.load_repetition()
+    profs = det.load_profit_fn()
+
+    sched = Scheduler(
+        machine_config_path=MACHINES,
+        job_config_path=JOBS,
+        operation_config_path=OPS,
+        slot_allocator=LinearSlotAllocator,
+    )
+    sched.reset(reps, profs)
+
+    # 한-두 번 step 해서 assignment / completion 엣지 포함시키기
+    sched.step(chosen_machine_id=0, chosen_job_id=0, chosen_repetition=0)
+    sched.step(chosen_machine_id=0, chosen_job_id=1, chosen_repetition=0)
+
+    G = build_graph_from_scheduler(sched)
+    data = graph_to_pyg(G)
+
+    # ── 노드 텐서 ────────────────────────────────────────────
+    assert data.x.shape[0] == G.number_of_nodes()          # 행 수 = 노드 수
+    assert data.x.shape[1] == 4                            # pad 포함 feature dim
+    assert data.node_type.shape[0] == G.number_of_nodes()  # 타입 길이 일치
+    # node_type 값이 (0,1) 범위인지
+    assert set(data.node_type.tolist()) <= {0, 1}
+
+    # ── 엣지 텐서 ────────────────────────────────────────────
+    num_edges = G.number_of_edges()
+    assert data.edge_index.shape == (2, num_edges)
+    assert data.edge_type.shape[0] == num_edges
+    assert data.edge_attr.shape[0] == num_edges
+    # edge_attr 는 assignment(3)·completion(1)·others(0)→pad 로 3 차원
+    assert data.edge_attr.shape[1] == 3
+
+    # assignment / completion edge_type 인덱스 존재 확인
+    assert 1 in data.edge_type.tolist()    # assignment
+    assert 3 in data.edge_type.tolist()    # completion

--- a/src/rl_scheduler/tests/graph/test_builder_and_draw.py
+++ b/src/rl_scheduler/tests/graph/test_builder_and_draw.py
@@ -1,0 +1,96 @@
+# tests/graph/test_graph_over_steps.py
+import matplotlib.pyplot as plt
+import networkx as nx
+from pathlib import Path
+
+import pytest
+
+from rl_scheduler.scheduler.scheduler import Scheduler
+from rl_scheduler.scheduler.slot_allocator import LinearSlotAllocator
+from rl_scheduler.contract_generator import DeterministicGenerator
+from rl_scheduler.graph.builder import build_graph_from_scheduler
+from rl_scheduler.graph.pyg_converter import graph_to_pyg
+from rl_scheduler.config_path import INSTANCES_DIR
+
+# ───────────────────────── 경로 세팅 ────────────────────────────
+CONTRACTS = INSTANCES_DIR / "contracts"  / "C-test0.json"
+MACHINES  = INSTANCES_DIR / "machines"   / "M-test0-2.json"
+JOBS      = INSTANCES_DIR / "jobs"       / "J-test0-2.json"
+OPS       = INSTANCES_DIR / "operations" / "O-test0.json"
+
+OUT_DIR   = Path("./graph_debug_png")
+OUT_DIR.mkdir(exist_ok=True)
+
+# ─────────────────────── 시각화 유틸 ────────────────────────────
+def quick_draw(G: nx.MultiDiGraph, title: str, save_path: Path | None = None):
+    pos = nx.spring_layout(G, seed=0)
+    node_colors = [
+        "skyblue" if G.nodes[n]["ntype"] == "operation" else "lightgreen"
+        for n in G.nodes
+    ]
+    edge_colors = [
+        "red"       if d.get("etype") == "completion"
+        else "blue" if d.get("etype") == "assignment"
+        else "gray" if d.get("etype") == "type_valid"
+        else "lightgray"
+        for _, _, d in G.edges(data=True)
+    ]
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    nx.draw(
+        G, pos, ax=ax, with_labels=True,
+        node_color=node_colors, edge_color=edge_colors,
+        node_size=900, font_size=8
+    )
+
+    edge_labels = {
+        (u, v): d["label"]
+        for u, v, d in G.edges(data=True) if "label" in d
+    }
+    nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels, font_size=7, ax=ax)
+    ax.set_title(title)
+    ax.axis("off")
+    plt.tight_layout()
+
+    if save_path:
+        fig.savefig(save_path, dpi=150)
+    else:
+        plt.show()
+
+    plt.close(fig)
+
+# ──────────────────────── 테스트 케이스 ─────────────────────────
+def test_graph_over_steps():
+    # 1) Scheduler 초기화
+    det = DeterministicGenerator(CONTRACTS)
+    reps  = det.load_repetition()
+    profs = det.load_profit_fn()
+
+    sched = Scheduler(
+        machine_config_path=MACHINES,
+        job_config_path=JOBS,
+        operation_config_path=OPS,
+        slot_allocator=LinearSlotAllocator,
+    )
+    sched.reset(reps, profs)
+
+    # 2) STEP 0 ─ 초기 그래프
+    G0 = build_graph_from_scheduler(sched)
+    _  = graph_to_pyg(G0)          # shape 확인만
+    quick_draw(G0, "Step 0 (initial)", OUT_DIR / "graph_step0.png")
+
+    # 3) STEP 1  (machine 0, job 0, rep 0)
+    sched.step(chosen_machine_id=0, chosen_job_id=0, chosen_repetition=0)
+    G1 = build_graph_from_scheduler(sched)
+    _  = graph_to_pyg(G1)
+    quick_draw(G1, "Step 1  (M0 → J0-R0)", OUT_DIR / "graph_step1.png")
+
+    # 4) STEP 2  (machine 0, job 1, rep 0)
+    sched.step(chosen_machine_id=0, chosen_job_id=1, chosen_repetition=0)
+    G2 = build_graph_from_scheduler(sched)
+    _  = graph_to_pyg(G2)
+    quick_draw(G2, "Step 2  (M0 → J1-R0)", OUT_DIR / "graph_step2.png")
+
+    # 간단 무결성 체크 (노드·엣지 수 증가 확인)
+    assert G1.number_of_edges() >= G0.number_of_edges()
+    assert G2.number_of_edges() >= G1.number_of_edges()


### PR DESCRIPTION
📌 개요
이 PR은 스케줄링 환경을 동적으로 Graph로 구성하고, 이를 PyTorch Geometric에서 사용할 수 있도록 Heterogeneous GNN 입력으로 변환하는 기능을 포함합니다. 이를 통해 향후 GNN 기반 강화학습 정책 학습이 가능해집니다.

✅ 주요 변경 사항
📁 graph/builder.py
Scheduler 상태를 기반으로 MultiDiGraph 생성

Node 종류: operation, machine

Edge 종류: assignment, completion, type_valid, logical

type_code를 자동 인코딩하여 정수형 feature로 매핑

📁 graph/pyg_converter.py
NetworkX 그래프를 torch_geometric.data.Data 객체로 변환

Node/Edge type에 따라 feature vector를 다르게 구성

node_type, edge_type 인덱스 필드 추가

Edge feature padding 처리 추가

📁 graph/sync.py
스케줄러가 step을 진행할 때마다 내부 그래프를 실시간으로 업데이트

on_assignment(), on_completion() 메서드로 assignment/completion edge 실시간 반영

기존 eligibility edge(type-valid)는 유지되도록 설계 변경

🧪 tests/graph/test_graph_over_steps.py
Step 0~2까지 Scheduler 상태 변화에 따라 그래프 생성 및 PyG 변환 테스트

assignment, completion edge가 정상 추가되는지 검증

각 단계 그래프 시각화 결과 저장 (graph_debug_png/ 디렉토리)

