### PR TITLE
ADD: RJSPGNN global read-out & robust graph validator

### DIFF
--- a/src/rl_scheduler/gnn/__init__.py
+++ b/src/rl_scheduler/gnn/__init__.py
@@ -1,0 +1,3 @@
+from .rjsp_gnn import RJSPGNN
+
+__all__ = ["RJSPGNN"]

--- a/src/rl_scheduler/gnn/rjsp_gnn.py
+++ b/src/rl_scheduler/gnn/rjsp_gnn.py
@@ -1,0 +1,225 @@
+import torch
+from torch_geometric.nn import HeteroConv, GINEConv, SAGEConv
+from torch_geometric.nn import Linear
+import torch.nn as nn
+from torch_geometric.data import HeteroData
+
+NUM_FEATURES_MACHINE = 3
+NUM_FEATURES_OPERATION = 4
+NUM_FEATURES_ASSIGNMENT = 3
+NUM_FEATURES_COMPLETION = 1
+
+
+class RJSPGNN(nn.Module):
+    def __init__(
+        self,
+        hidden_dim=64,
+        num_features_machine=NUM_FEATURES_MACHINE,
+        num_features_operation=NUM_FEATURES_OPERATION,
+        num_features_assignment=NUM_FEATURES_ASSIGNMENT,
+        num_features_completion=NUM_FEATURES_COMPLETION,
+    ):
+        super().__init__()
+        self.convs = nn.ModuleList()
+        self.num_features_machine = num_features_machine
+        self.num_features_operation = num_features_operation
+        self.num_features_assignment = num_features_assignment
+        self.num_features_completion = num_features_completion
+        self.hidden_dim = hidden_dim
+
+        # Node Encoders
+        self.machine_encoder = Linear(num_features_machine, hidden_dim)
+        self.operation_encoder = Linear(num_features_operation, hidden_dim)
+
+        # Message Passing Layers
+        self.convs.append(
+            HeteroConv(
+                {
+                    ("machine", "assignment", "operation"): GINEConv(
+                        nn=Linear(hidden_dim, hidden_dim),
+                        edge_dim=num_features_assignment,
+                    ),
+                    ("operation", "completion", "operation"): GINEConv(
+                        nn=Linear(hidden_dim, hidden_dim),
+                        edge_dim=num_features_completion,
+                    ),
+                    ("operation", "type_valid", "machine"): SAGEConv(
+                        (-1, -1), hidden_dim
+                    ),
+                    ("operation", "logical", "operation"): SAGEConv(
+                        (-1, -1), hidden_dim
+                    ),
+                },
+                aggr="mean",
+            )
+        )
+
+    def forward(self, x_dict, edge_index_dict, edge_attr_dict):
+        # 1) Encoding node features
+        x_dict["machine"] = self.machine_encoder(x_dict["machine"])
+        x_dict["operation"] = self.operation_encoder(x_dict["operation"])
+
+        # 2) Message passing
+        for conv in self.convs:
+            x_dict = conv(x_dict, edge_index_dict, edge_attr_dict)
+
+        # 3) Global Embedding for each node type
+        g_machine = x_dict["machine"].mean(dim=0, keepdim=True)
+        g_operation = x_dict["operation"].mean(dim=0, keepdim=True)
+
+        # 4) Concatenate global embeddings
+        # [1, 2 * hidden_dim]
+        g = torch.cat([g_machine, g_operation], dim=-1)
+
+        return x_dict, g
+
+    def check_validity(self, x_dict, edge_index_dict, edge_attr_dict):
+        required_node_types = ["machine", "operation"]
+        required_edge_types = [
+            ("machine", "assignment", "operation"),
+            ("operation", "completion", "operation"),
+            ("operation", "type_valid", "machine"),
+            ("operation", "logical", "operation"),
+        ]
+
+        # Node types should be exactly as required
+        if set(x_dict.keys()) != set(required_node_types):
+            raise ValueError(f"Node types in x_dict should be {required_node_types}.")
+
+        # Edge types should be exactly as required
+        if set(edge_index_dict.keys()) != set(required_edge_types):
+            raise ValueError(
+                f"Edge types in edge_index_dict should be " f"{required_edge_types}."
+            )
+
+        # Assignment and Completion edges should have features
+        if edge_attr_dict[("machine", "assignment", "operation")] is None:
+            raise ValueError("Edge attributes for assignment edges should not be None.")
+
+        if edge_attr_dict[("operation", "completion", "operation")] is None:
+            raise ValueError("Edge attributes for completion edges should not be None.")
+
+        # Type_valid edges should have no features
+        if edge_attr_dict.get(("operation", "type_valid", "machine")) is not None:
+            raise ValueError("Type_valid edges should not have features.")
+
+        # Logical edges should have no features
+        if edge_attr_dict.get(("operation", "logical", "operation")) is not None:
+            raise ValueError("Logical edges should not have features.")
+
+        # Logical edges should be bidirectional
+        logical_edge_index = edge_index_dict[("operation", "logical", "operation")]
+        if logical_edge_index.dim() != 2 or logical_edge_index.size(0) != 2:
+            raise ValueError("Logical edge_index must be of shape [2, num_edges].")
+
+        # Convert to sets of tuples for easy membership checking
+        src, dst = logical_edge_index[0], logical_edge_index[1]
+        edge_pairs = {(int(s), int(d)) for s, d in zip(src.tolist(), dst.tolist())}
+        for s, d in edge_pairs:
+            if (d, s) not in edge_pairs:
+                raise ValueError(
+                    "Logical edges must be bidirectional: "
+                    f"missing reverse edge ({d} -> {s}) for ({s} -> {d})."
+                )
+
+        print("Graph structure is valid.")
+
+    def reset_parameters(self):
+        for conv in self.convs:
+            conv.reset_parameters()
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.convs})"
+
+
+if __name__ == "__main__":
+    # Example Heterogeneous graph data
+    data = HeteroData()
+
+    num_machines = 5
+    num_operations = 10
+    num_edges_assignment = 3
+    num_edges_completion = 4
+    num_edges_type_valid = 10
+    num_edges_logical = ((num_operations // num_machines) - 1) * num_machines
+
+    # Nodes
+    # [num_machines, num_features_machine]
+    data["machine"].x = torch.randn(num_machines, NUM_FEATURES_MACHINE)
+    # [num_operations, num_features_operation]
+    data["operation"].x = torch.randn(num_operations, NUM_FEATURES_OPERATION)
+
+    # Edges
+    # Assignment
+    # [2, num_edges_assignment]
+    assign_src = torch.randint(0, num_machines, (1, num_edges_assignment))
+    assign_dst = torch.randint(
+        0,
+        num_operations,
+        (
+            1,
+            num_edges_assignment,
+        ),
+    )
+    edge_index_assignment = torch.cat([assign_src, assign_dst], dim=0)
+    data["machine", "assignment", "operation"].edge_index = edge_index_assignment
+    # [num_edges_assignment, num_features_assignment]
+    data["machine", "assignment", "operation"].edge_attr = torch.randn(
+        num_edges_assignment, NUM_FEATURES_ASSIGNMENT
+    )
+
+    # Completion
+    # [2, num_edges_completion]
+    comp_src = torch.randint(0, num_operations, (1, num_edges_completion))
+    comp_dst = torch.randint(
+        0,
+        num_operations,
+        (
+            1,
+            num_edges_completion,
+        ),
+    )
+    edge_index_completion = torch.cat([comp_src, comp_dst], dim=0)
+    data["operation", "completion", "operation"].edge_index = edge_index_completion
+    # [num_edges_completion, num_features_completion]
+    data["operation", "completion", "operation"].edge_attr = torch.randn(
+        num_edges_completion, NUM_FEATURES_COMPLETION
+    )
+
+    # Type-valid
+    # no features
+    # [2, num_edges_type_valid]
+    type_valid_src = torch.randint(0, num_operations, (1, num_edges_type_valid))
+    type_valid_dst = torch.randint(
+        0,
+        num_machines,
+        (
+            1,
+            num_edges_type_valid,
+        ),
+    )
+    edge_index_type_valid = torch.cat([type_valid_src, type_valid_dst], dim=0)
+    data["operation", "type_valid", "machine"].edge_index = edge_index_type_valid
+
+    # Logical
+    # no features and unidirectional
+    # [2, num_edges_type_valid]
+    logical_src = torch.randint(0, num_operations, (1, num_edges_logical // 2))
+    logical_dst = torch.randint(0, num_operations, (1, num_edges_logical // 2))
+    edge_index_logical = torch.cat([logical_src, logical_dst], dim=0)
+    # Duplicate the edges to make it bidirectional
+    edge_index_logical = torch.cat(
+        [edge_index_logical, edge_index_logical.flip(0)], dim=1
+    )
+    data["operation", "logical", "operation"].edge_index = edge_index_logical
+
+    print(f"Data: {data}")
+
+    # Initialize the model
+    model = RJSPGNN(hidden_dim=64)
+    model.check_validity(data.x_dict, data.edge_index_dict, data.edge_attr_dict)
+
+    # Forward pass
+    out_x_dict, g = model(data.x_dict, data.edge_index_dict, data.edge_attr_dict)
+    print(f"Output x_dict: {out_x_dict}")
+    print(f"Global embedding g: {g}")


### PR DESCRIPTION
* **rjsp_gnn.py** • Added per-type mean pooling and concatenation to produce a global graph embedding `g` (shape = [1, 2·hidden_dim]). • Introduced `machine_encoder` / `operation_encoder` linear layers to map raw features to common hidden_dim before message passing. • Extended `check_validity()` – Verifies presence of required node/edge types – Ensures assignment & completion edges carry features, while `type_valid`/`logical` carry none – New bidirectionality check for `logical` edges; raises descriptive error if reverse edge missing. • Updated forward pass: encoding → HeteroConv → mean-pool per node type → concatenate → return `(x_dict, g)`. • Added `reset_parameters()` for reproducible weight re-initialisation.

Result: RJSPGNN now outputs a usable graph-level embedding and prevents malformed heterogeneous graphs at construction time.